### PR TITLE
fix(checker): skip Deny statements in wildcard detection

### DIFF
--- a/policy_checker.py
+++ b/policy_checker.py
@@ -21,6 +21,11 @@ issues = 0
 
 # Loop to iterate through all the policy statements.
 for statement in policy.get("Statement", []):
+    
+    # Check if "Effect" is Deny - continue if so.
+    effect = statement.get("Effect")
+    if effect == "Deny":
+        continue
 
     # Check if "Action" is overly permissive.
     action = statement.get("Action")
@@ -38,7 +43,7 @@ for statement in policy.get("Statement", []):
         issues += 1
     elif isinstance(resource, list) and "*" in resource:
         print(f"[FAIL] Statement \"{statement.get('Sid')}\": Resource is \"*\"")
-        issues += 1   
+        issues += 1
 
 # Print final results. 
 print(f"\nResults: {issues} issues found.")

--- a/test-policy.json
+++ b/test-policy.json
@@ -21,6 +21,12 @@
         "Effect": "Allow",
         "Action": "*",
         "Resource": "*"
-      }
+      },
+      {
+        "Sid": "DenyAll",
+        "Effect": "Deny",
+        "Action": "*",
+        "Resource": "*"
+      }  
     ]
   }


### PR DESCRIPTION
## Summary
- Add Effect field check at the start of the statement loop
- Deny statements skipped via continue before wildcard checks
- Prevents false positives for legitimate deny-all patterns

## Test Plan
- [ ] Allow statements with wildcards are flagged
- [ ] Deny statements with wildcards are not flagged
- [ ] No regression on existing detection

Closes #2