### PR TITLE
feat(checker): detect service-level wildcard actions

### DIFF
--- a/policy_checker.py
+++ b/policy_checker.py
@@ -66,6 +66,18 @@ for statement in policy.get("Statement", []):
     elif isinstance(action, list) and "*" in action:
         print(f"[FAIL] Statement \"{statement.get('Sid')}\": Action is \"*\"")
         issues += 1
+        
+    # Check for service-level wildcards (e.g., "s3:*", "iam:*").
+    # These grant full access to a specific AWS service, which is risky
+    # but less severe than a full "*" wildcard.
+    if isinstance(action, str) and action.endswith(":*"):
+        print(f"[WARN] Statement \"{statement.get('Sid')}\": Action \"{action}\" grants full access to a service")
+        issues += 1
+    elif isinstance(action, list):
+        for item in action:
+            if isinstance(item, str) and item.endswith(":*"):
+                print(f"[WARN] Statement \"{statement.get('Sid')}\": Action \"{item}\" grants full access to a service")
+                issues += 1
 
     # Check if "Resource" is a wildcard ("*"), meaning all resources are affected.
     # Same string-or-list check as above.

--- a/test-policy.json
+++ b/test-policy.json
@@ -27,7 +27,19 @@
         "Effect": "Deny",
         "Action": "*",
         "Resource": "*"
-      }  
+      },
+      {
+        "Sid": "ServiceWildcardList",
+        "Effect": "Allow",
+        "Action": ["s3:GetObject", "iam:*"],
+        "Resource": "*"
+      },
+      {
+        "Sid": "ServiceWildcardString",
+        "Effect": "Allow",
+        "Action": "s3:*",
+        "Resource": "*"
+      }
     ]
   }
   


### PR DESCRIPTION
## Summary
- Add service-level wildcard detection using .endswith(':*')
- Handle both string and list Action formats
- Use [WARN] severity distinct from [FAIL]
- Add ServiceWildcard test case to test-policy.json

## Controls Addressed
- AC-6: Service-level wildcards grant excessive permissions
- CM-7: Only necessary service actions should be permitted

## Test Plan
- [ ] Detects s3:* as service-level wildcard
- [ ] Both string and list formats handled
- [ ] No regression on existing detection

Closes #8