### PR TITLE
test(checker): add unit tests and refactor for testability

### DIFF
--- a/policy_checker.py
+++ b/policy_checker.py
@@ -14,82 +14,111 @@ import argparse
 import json
 import sys
 
-# Create a parser variable with a description of the tool.
-parser = argparse.ArgumentParser(description="Check an AWS IAM policy JSON file for overly permissive statements.")
+def check_policy(policy):
+    """
+    Check a parsed IAM policy dictionary for overly permissive statements.
 
-# Add a positional argument for the file name.
-parser.add_argument("filename", help="Path to the JSON policy file.")
+    Args:
+        policy: A dictionary representing a parsed IAM policy JSON.
 
-# Parse the command-line arguments.
-args = parser.parse_args()
+    Returns:
+        A list of finding dictionaries, each with keys:
+            "severity" - "FAIL" or "WARN"
+            "sid"      - The statement's Sid (or None if missing)
+            "message"  - A human-readable description of the issue
+    """
+    findings = []
 
-filename = args.filename
+    for statement in policy.get("Statement", []):
 
-# Attempt to open and parse the JSON policy file.
-# Each `except` block handles a different type of error that could occur.
-try:
-    with open(filename, "r") as file:
-        policy = json.load(file)
-except FileNotFoundError:
-    print(f"{filename} doesn't exist.", file=sys.stderr)
-    sys.exit(2)
-except json.JSONDecodeError:
-    print(f"{filename} contains invalid JSON.", file=sys.stderr)
-    sys.exit(2)
-except PermissionError:
-    print(f"{filename} can't be read.", file=sys.stderr)
-    sys.exit(2)
+        # Skip "Deny" statements - they restrict access rather than grant it,
+        # so wildcards in Deny statements are not a security concern.
+        effect = statement.get("Effect")
+        if effect == "Deny":
+            continue
 
-print(f"Checking: {filename}")
+        sid = statement.get("Sid")
 
-# Counter to track how many issues are found.
-issues = 0
+        # Check if "Action" is a wildcard ("*"), meaning all actions are allowed.
+        # The value can be either a single string or a list of strings,
+        # so we check for both cases using isinstance().
+        action = statement.get("Action")
+        if isinstance(action, str) and action == "*":
+            findings.append({
+                "severity": "FAIL",
+                "sid": sid,
+                "message": "Action is \"*\""
+            })
+        elif isinstance(action, list) and "*" in action:
+            findings.append({
+                "severity": "FAIL",
+                "sid": sid,
+                "message": "Action is \"*\""
+            })
 
-# Iterate through each statement in the policy.
-# .get() returns a default (here, an empty list) if the key is missing,
-# which avoids a KeyError.
-for statement in policy.get("Statement", []):
-    
-    # Skip "Deny" statements — they restrict access rather than grant it,
-    # so wildcards in Deny statements are not a security concern.
-    effect = statement.get("Effect")
-    if effect == "Deny":
-        continue
+        # Check for service-level wildcards (e.g., "s3:*", "iam:*").
+        # These grant full access to a specific AWS service, which is risky
+        # but less severe than a full "*" wildcard.
+        if isinstance(action, str) and action.endswith(":*"):
+            findings.append({
+                "severity": "WARN",
+                "sid": sid,
+                "message": f"Action \"{action}\" grants full access to a service"
+            })
+        elif isinstance(action, list):
+            for item in action:
+                if isinstance(item, str) and item.endswith(":*"):
+                    findings.append({
+                        "severity": "WARN",
+                        "sid": sid,
+                        "message": f"Action \"{item}\" grants full access to a service"
+                    })
 
-    # Check if "Action" is a wildcard ("*"), meaning all actions are allowed.
-    # The value can be either a single string or a list of strings,
-    # so we check for both cases using isinstance().
-    action = statement.get("Action")
-    if isinstance(action, str) and action == "*":
-        print(f"[FAIL] Statement \"{statement.get('Sid')}\": Action is \"*\"")
-        issues += 1
-    elif isinstance(action, list) and "*" in action:
-        print(f"[FAIL] Statement \"{statement.get('Sid')}\": Action is \"*\"")
-        issues += 1
-        
-    # Check for service-level wildcards (e.g., "s3:*", "iam:*").
-    # These grant full access to a specific AWS service, which is risky
-    # but less severe than a full "*" wildcard.
-    if isinstance(action, str) and action.endswith(":*"):
-        print(f"[WARN] Statement \"{statement.get('Sid')}\": Action \"{action}\" grants full access to a service")
-        issues += 1
-    elif isinstance(action, list):
-        for item in action:
-            if isinstance(item, str) and item.endswith(":*"):
-                print(f"[WARN] Statement \"{statement.get('Sid')}\": Action \"{item}\" grants full access to a service")
-                issues += 1
+        # Check if "Resource" is a wildcard ("*"), meaning all resources are affected.
+        # Same string-or-list check as above.
+        resource = statement.get("Resource")
+        if isinstance(resource, str) and resource == "*":
+            findings.append({
+                "severity": "FAIL",
+                "sid": sid,
+                "message": "Resource is \"*\""
+            })
+        elif isinstance(resource, list) and "*" in resource:
+            findings.append({
+                "severity": "FAIL",
+                "sid": sid,
+                "message": "Resource is \"*\""
+            })
 
-    # Check if "Resource" is a wildcard ("*"), meaning all resources are affected.
-    # Same string-or-list check as above.
-    resource = statement.get("Resource")
-    if isinstance(resource, str) and resource == "*":
-        print(f"[FAIL] Statement \"{statement.get('Sid')}\": Resource is \"*\"")
-        issues += 1
-    elif isinstance(resource, list) and "*" in resource:
-        print(f"[FAIL] Statement \"{statement.get('Sid')}\": Resource is \"*\"")
-        issues += 1
+    return findings
 
-# Print the final results.
-print(f"\nResults: {issues} issues found.")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Check an AWS IAM policy JSON file for overly permissive statements."
+    )
+    parser.add_argument("filename", help="Path to the JSON policy file.")
+    args = parser.parse_args()
+    filename = args.filename
 
-sys.exit(1 if issues > 0 else 0)
+    try:
+        with open(filename, "r") as file:
+            policy = json.load(file)
+    except FileNotFoundError:
+        print(f"{filename} doesn't exist.", file=sys.stderr)
+        sys.exit(2)
+    except json.JSONDecodeError:
+        print(f"{filename} contains invalid JSON.", file=sys.stderr)
+        sys.exit(2)
+    except PermissionError:
+        print(f"{filename} can't be read.", file=sys.stderr)
+        sys.exit(2)
+
+    print(f"Checking: {filename}")
+
+    findings = check_policy(policy)
+
+    for finding in findings:
+        print(f"[{finding['severity']}] Statement \"{finding['sid']}\": {finding['message']}")
+
+    print(f"\nResults: {len(findings)} issues found.")
+    sys.exit(1 if findings else 0)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,0 +1,135 @@
+from policy_checker import check_policy
+
+def test_clean_policy():
+    """No wildcards — findings should be empty."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "AllowSpecific",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::my-bucket/*"
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert len(findings) == 0
+
+
+def test_action_wildcard_string():
+    """Action is "*" as a string — should be FAIL."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "WildAction",
+                "Effect": "Allow",
+                "Action": "*",
+                "Resource": "arn:aws:s3:::my-bucket/*"
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "FAIL"
+    assert findings[0]["sid"] == "WildAction"
+
+
+def test_action_wildcard_in_list():
+    """Action "*" inside a list — should be FAIL."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "WildActionList",
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", "*"],
+                "Resource": "arn:aws:s3:::my-bucket/*"
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "FAIL"
+
+
+def test_resource_wildcard_string():
+    """Resource is "*" as a string — should be FAIL."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "WildResource",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "*"
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "FAIL"
+
+
+def test_resource_wildcard_in_list():
+    """Resource "*" inside a list — should be FAIL."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "WildResourceList",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": ["arn:aws:s3:::my-bucket/*", "*"]
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "FAIL"
+
+
+def test_deny_statement_skipped():
+    """Deny statements with wildcards should be skipped entirely."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "DenyAll",
+                "Effect": "Deny",
+                "Action": "*",
+                "Resource": "*"
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert len(findings) == 0
+
+
+def test_service_wildcard_string():
+    """Service-level wildcard as a string (e.g., "s3:*") — should be WARN."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "ServiceWild",
+                "Effect": "Allow",
+                "Action": "s3:*",
+                "Resource": "arn:aws:s3:::my-bucket/*"
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "WARN"
+
+
+def test_service_wildcard_in_list():
+    """Service-level wildcard in a list (e.g., "iam:*") — should be WARN."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "ServiceWildList",
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", "iam:*"],
+                "Resource": "arn:aws:s3:::my-bucket/*"
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "WARN"


### PR DESCRIPTION
## Summary
- Extract check_policy() function returning a list of finding dicts
- Add if __name__ == '__main__' guard to isolate CLI logic
- Create tests/ directory with __init__.py and test_checker.py
- 8 test cases covering all detection logic

## Test Plan
- [ ] check_policy() extracted and testable
- [ ] if __name__ guard in place
- [ ] Clean policy, wildcard Action/Resource, Deny skip, service wildcard tests pass

Closes #7