### PR TITLE
docs: add compliance control mappings to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ python policy_checker.py policy.json --output json > results.json
 - Maps findings to NIST 800-53 compliance controls.
 - Prints a summary of the results.
 
+## Compliance Mapping
+
+Each check maps to controls across NIST 800-53 Rev 5, FedRAMP, and CJIS v6.0:
+
+| Check | NIST 800-53 | FedRAMP | CJIS Security Policy |
+|-------|-------------|---------|----------------------|
+| Action is `*` | AC-6 (Least Privilege) | AC-6 | 5.5.2.1 (Least Privilege) |
+| Resource is `*` | AC-3 (Access Enforcement) | AC-3 | 5.5.2 (Access Control Enforcement) |
+| Service-level wildcard (e.g., `s3:*`) | AC-6 (Least Privilege) | AC-6 | 5.5.2.1 (Least Privilege) |
+| Overly permissive IAM policy | AC-2 (Account Management) | AC-2 | 5.5.1 (Account Management) |
+
+### How This Supports Audits
+
+The JSON output (`--output json`) provides machine-readable evidence for compliance assessments. Auditors can use this output to verify CM-6 (Configuration Settings), CM-7 (Least Functionality), and SA-11 (Developer Testing) controls. Each finding includes the compliance framework, control ID, severity, and a UTC timestamp for audit trail purposes.
+
 ## Output Formats
 
 ### Text (default)


### PR DESCRIPTION
## Summary
- Add Compliance Mapping section to README with NIST 800-53, FedRAMP, and CJIS control mappings
- Add How This Supports Audits subsection

## Test Plan
- [ ] Compliance Mapping section present
- [ ] Control mapping table accurate
- [ ] Audit guidance subsection present

Closes #9