### PR TITLE
ci: add GitHub Actions workflow for policy scanning

### DIFF
--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -1,0 +1,43 @@
+name: Policy Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: pip install pytest
+
+      - name: Run unit tests
+        run: python -m pytest tests/ -v
+
+  policy-scan:
+    name: Policy Compliance Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run policy checker (text)
+        run: python policy_checker.py test-policy.json
+
+      - name: Run policy checker (JSON evidence)
+        if: always()
+        run: python policy_checker.py test-policy.json --output json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # policy_checker.py
 
+[![Policy Check](https://github.com/0xBahalaNa/policy_checker/actions/workflows/policy-check.yml/badge.svg)](https://github.com/0xBahalaNa/policy_checker/actions/workflows/policy-check.yml)
+
 This script loads an AWS IAM policy file and checks if it is overly permissive.
 
 ## Usage


### PR DESCRIPTION
## Summary
- Add .github/workflows/policy-check.yml with unit tests and policy scan jobs
- Pipeline fails when overly permissive policies detected
- JSON evidence output step runs regardless of scan result
- Add CI status badge to README

## Controls Addressed
- SA-11: Automated security testing in pipeline
- CM-3: Policy validation before merge

## Test Plan
- [ ] Workflow runs on PR events
- [ ] Unit tests pass, policy scan detects violations
- [ ] CI badge renders in README

Closes #11