### PR TITLE
feat(checker): add CJIS v6.0 CM-6 configuration baseline checks

### DIFF
--- a/policy_checker.py
+++ b/policy_checker.py
@@ -19,6 +19,8 @@ CONTROL_MAP = {
     "action_wildcard":  {"framework": "NIST 800-53", "control_id": "AC-6"},
     "service_wildcard": {"framework": "NIST 800-53", "control_id": "AC-6"},
     "resource_wildcard": {"framework": "NIST 800-53", "control_id": "AC-3"},
+    "cji_missing_mfa":  {"framework": "CJIS v6.0", "control_id": "IA-2"},
+    "cji_cross_account": {"framework": "CJIS v6.0", "control_id": "AC-2"},
 }
 
 def check_policy(policy):
@@ -106,6 +108,82 @@ def check_policy(policy):
 
     return findings
 
+def check_cjis_policy(policy):
+    """
+    Check a parsed IAM policy for CJIS v6.0 specific requirements.
+
+    Checks for:
+        - Policies accessing CJI resources without MFA conditions (IA-2)
+        - Policies allowing cross-account access to CJI resources (AC-2)
+
+    Args:
+        policy: A dictionary representing a parsed IAM policy JSON.
+
+    Returns:
+        A list of finding dictionaries with the same structure as check_policy().
+    """
+    findings = []
+
+    for statement in policy.get("Statement", []):
+        if statement.get("Effect") == "Deny":
+            continue
+
+        sid = statement.get("Sid")
+        resource = statement.get("Resource")
+        condition = statement.get("Condition", {})
+
+        # Normalize resource to a list for consistent checking.
+        if isinstance(resource, str):
+            resources = [resource]
+        elif isinstance(resource, list):
+            resources = resource
+        else:
+            continue
+
+        # Check if any resource references CJI data (by naming pattern or tag).
+        has_cji_resource = any(
+            "cji" in r.lower() or "criminal-justice" in r.lower()
+            for r in resources
+        )
+        if not has_cji_resource:
+            continue
+
+        # CJIS IA-2: CJI resources should require MFA.
+        mfa_required = (
+            condition.get("Bool", {}).get("aws:MultiFactorAuthPresent") == "true"
+        )
+        if not mfa_required:
+            findings.append({
+                "severity": "FAIL",
+                "sid": sid,
+                "message": "CJI resource access without MFA condition (aws:MultiFactorAuthPresent)",
+                "type": "cji_missing_mfa"
+            })
+
+        # CJIS AC-2: CJI resources should not allow cross-account access
+        # without explicit principal restrictions.
+        principal = statement.get("Principal")
+        if principal and principal != "*":
+            # Check if principal references external accounts.
+            principals = [principal] if isinstance(principal, str) else []
+            if isinstance(principal, dict):
+                principals = principal.get("AWS", [])
+                if isinstance(principals, str):
+                    principals = [principals]
+            for p in principals:
+                if ":root" in p and "arn:aws:iam::" in p:
+                    account_condition = condition.get("StringEquals", {}).get("aws:PrincipalOrgID")
+                    if not account_condition:
+                        findings.append({
+                            "severity": "WARN",
+                            "sid": sid,
+                            "message": f"Cross-account access to CJI resource without org restriction",
+                            "type": "cji_cross_account"
+                        })
+                        break
+
+    return findings
+
 def enrich_findings(findings, resource):
     """
     Enrich raw findings with compliance framework metadata and timestamps.
@@ -171,6 +249,7 @@ if __name__ == "__main__":
         sys.exit(2)
 
     findings = check_policy(policy)
+    findings.extend(check_cjis_policy(policy))
 
     if args.output == "json":
         enriched = enrich_findings(findings, resource=filename)

--- a/test-policy.json
+++ b/test-policy.json
@@ -39,6 +39,21 @@
         "Effect": "Allow",
         "Action": "s3:*",
         "Resource": "*"
+      },
+      {
+        "Sid": "CJIAccessNoMFA",
+        "Effect": "Allow",
+        "Action": "s3:GetObject",
+        "Resource": "arn:aws:s3:::cji-data-bucket/*"
+      },
+      {
+        "Sid": "CJICrossAccount",
+        "Effect": "Allow",
+        "Action": "s3:GetObject",
+        "Resource": "arn:aws:s3:::cji-evidence-store/*",
+        "Principal": {
+          "AWS": "arn:aws:iam::123456789012:root"
+        }
       }
     ]
   }

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,4 +1,4 @@
-from policy_checker import check_policy, enrich_findings
+from policy_checker import check_policy, check_cjis_policy, enrich_findings
 from datetime import datetime
 
 def test_enrich_findings_timestamp_format():
@@ -169,3 +169,93 @@ def test_findings_include_type_key():
     }
     findings = check_policy(policy)
     assert findings[0]["type"] == "action_wildcard"
+
+
+def test_cjis_missing_mfa():
+    """CJI resource access without MFA condition — should be FAIL."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "CJINoMFA",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::cji-data-bucket/*"
+            }
+        ]
+    }
+    findings = check_cjis_policy(policy)
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "FAIL"
+    assert findings[0]["type"] == "cji_missing_mfa"
+
+
+def test_cjis_with_mfa_clean():
+    """CJI resource access with MFA condition — should pass."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "CJIWithMFA",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::cji-data-bucket/*",
+                "Condition": {
+                    "Bool": {"aws:MultiFactorAuthPresent": "true"}
+                }
+            }
+        ]
+    }
+    findings = check_cjis_policy(policy)
+    assert len(findings) == 0
+
+
+def test_cjis_cross_account_no_org_restriction():
+    """Cross-account access to CJI resource without org restriction — should be WARN."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "CJICrossAcct",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::cji-evidence-store/*",
+                "Principal": {
+                    "AWS": "arn:aws:iam::123456789012:root"
+                }
+            }
+        ]
+    }
+    findings = check_cjis_policy(policy)
+    assert len(findings) >= 1
+    types = [f["type"] for f in findings]
+    assert "cji_cross_account" in types
+
+
+def test_cjis_non_cji_resource_skipped():
+    """Non-CJI resources should not trigger CJIS checks."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "RegularAccess",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::regular-bucket/*"
+            }
+        ]
+    }
+    findings = check_cjis_policy(policy)
+    assert len(findings) == 0
+
+
+def test_cjis_deny_skipped():
+    """Deny statements should be skipped by CJIS checks."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "DenyCJI",
+                "Effect": "Deny",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::cji-data-bucket/*"
+            }
+        ]
+    }
+    findings = check_cjis_policy(policy)
+    assert len(findings) == 0


### PR DESCRIPTION
## Summary
- Add check_cjis_policy() with two CJIS v6.0 specific checks
- Detect CJI resource access without MFA condition (IA-2)
- Detect cross-account access to CJI resources without org restriction (AC-2)
- CJI resources identified by naming pattern in ARN
- 5 new unit tests (16 total)

## Controls Addressed
- IA-2: MFA enforcement for CJI resource access
- AC-2: Cross-account access restrictions for CJI resources

## Test Plan
- [ ] MFA missing on CJI resource flagged
- [ ] Cross-account access without org restriction flagged
- [ ] Clean CJIS policy produces no findings
- [ ] All 16 tests pass

Closes #15