### PR TITLE
feat: detect NotAction, NotResource, and NotPrincipal fields

### DIFF
--- a/policy_checker.py
+++ b/policy_checker.py
@@ -27,6 +27,9 @@ CONTROL_MAP = {
     "action_wildcard":  {"framework": "NIST 800-53", "control_id": "AC-6"},
     "service_wildcard": {"framework": "NIST 800-53", "control_id": "AC-6"},
     "resource_wildcard": {"framework": "NIST 800-53", "control_id": "AC-3"},
+    "not_action":       {"framework": "NIST 800-53", "control_id": "AC-6"},
+    "not_resource":     {"framework": "NIST 800-53", "control_id": "AC-3"},
+    "not_principal":    {"framework": "NIST 800-53", "control_id": "AC-6"},
     "cji_missing_mfa":  {"framework": "CJIS v6.0", "control_id": "IA-2"},
     "cji_cross_account": {"framework": "CJIS v6.0", "control_id": "AC-2"},
 }
@@ -114,6 +117,36 @@ def check_policy(policy):
                 "type": "resource_wildcard"
             })
 
+        # Check for inverse IAM fields (NotAction, NotResource, NotPrincipal).
+        # These are privilege escalation vectors: e.g., "NotAction": "s3:GetObject"
+        # allows every action EXCEPT the named one, effectively granting near-admin.
+        if "NotAction" in statement:
+            findings.append({
+                "severity": "FAIL",
+                "sid": sid,
+                "message": "NotAction grants all actions except those listed"
+                          " (privilege escalation risk)",
+                "type": "not_action"
+            })
+
+        if "NotResource" in statement:
+            findings.append({
+                "severity": "FAIL",
+                "sid": sid,
+                "message": "NotResource applies to all resources except those"
+                          " listed (privilege escalation risk)",
+                "type": "not_resource"
+            })
+
+        if "NotPrincipal" in statement:
+            findings.append({
+                "severity": "FAIL",
+                "sid": sid,
+                "message": "NotPrincipal allows all principals except those"
+                          " listed (privilege escalation risk)",
+                "type": "not_principal"
+            })
+
     return findings
 
 def check_cjis_policy(policy):
@@ -175,6 +208,27 @@ def check_cjis_policy(policy):
                 "message": "CJI resource access without MFA condition"
                           " (aws:MultiFactorAuthPresent)",
                 "type": "cji_missing_mfa"
+            })
+
+        # Flag inverse IAM fields on CJI resource statements.
+        # NotAction on a CJI resource allows nearly all actions on CJI data.
+        # NotPrincipal on a CJI resource allows nearly all principals access.
+        if "NotAction" in statement:
+            findings.append({
+                "severity": "FAIL",
+                "sid": sid,
+                "message": "CJI resource statement uses NotAction"
+                          " (privilege escalation risk)",
+                "type": "not_action"
+            })
+
+        if "NotPrincipal" in statement:
+            findings.append({
+                "severity": "FAIL",
+                "sid": sid,
+                "message": "CJI resource statement uses NotPrincipal"
+                          " (privilege escalation risk)",
+                "type": "not_principal"
             })
 
         # CJIS AC-2: CJI resources should not allow cross-account access

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -183,6 +183,58 @@ def test_findings_include_type_key():
     assert findings[0]["type"] == "action_wildcard"
 
 
+def test_not_action_flagged():
+    """NotAction in an Allow statement — should be FAIL."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "DangerousNotAction",
+                "Effect": "Allow",
+                "NotAction": "s3:GetObject",
+                "Resource": "arn:aws:s3:::my-bucket/*"
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert any(f["type"] == "not_action" for f in findings)
+    assert any(f["severity"] == "FAIL" for f in findings if f["type"] == "not_action")
+
+
+def test_not_resource_flagged():
+    """NotResource in an Allow statement — should be FAIL."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "DangerousNotResource",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "NotResource": "arn:aws:s3:::public-bucket/*"
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert any(f["type"] == "not_resource" for f in findings)
+    assert any(f["severity"] == "FAIL" for f in findings if f["type"] == "not_resource")
+
+
+def test_not_principal_flagged():
+    """NotPrincipal in an Allow statement — should be FAIL."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "DangerousNotPrincipal",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::my-bucket/*",
+                "NotPrincipal": {"AWS": "arn:aws:iam::123456789012:root"}
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert any(f["type"] == "not_principal" for f in findings)
+    assert any(f["severity"] == "FAIL" for f in findings if f["type"] == "not_principal")
+
+
 def test_cjis_missing_mfa():
     """CJI resource access without MFA condition — should be FAIL."""
     policy = {
@@ -309,3 +361,38 @@ def test_cjis_deny_skipped():
     }
     findings = check_cjis_policy(policy)
     assert len(findings) == 0
+
+
+def test_cjis_not_action_flagged():
+    """NotAction on a CJI resource — should be FAIL."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "CJINotAction",
+                "Effect": "Allow",
+                "NotAction": "s3:GetObject",
+                "Resource": "arn:aws:s3:::cji-data-bucket/*"
+            }
+        ]
+    }
+    findings = check_cjis_policy(policy)
+    assert any(f["type"] == "not_action" for f in findings)
+    assert any(f["severity"] == "FAIL" for f in findings if f["type"] == "not_action")
+
+
+def test_cjis_not_principal_flagged():
+    """NotPrincipal on a CJI resource — should be FAIL."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "CJINotPrincipal",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::cji-data-bucket/*",
+                "NotPrincipal": {"AWS": "arn:aws:iam::123456789012:root"}
+            }
+        ]
+    }
+    findings = check_cjis_policy(policy)
+    assert any(f["type"] == "not_principal" for f in findings)
+    assert any(f["severity"] == "FAIL" for f in findings if f["type"] == "not_principal")


### PR DESCRIPTION
## Summary
- Detect NotAction, NotResource, and NotPrincipal in check_policy() — inverse IAM fields that bypass all wildcard checks
- Detect NotAction and NotPrincipal on CJI resource statements in check_cjis_policy()
- Add 3 new finding types (not_action, not_resource, not_principal) to CONTROL_MAP

## Controls Addressed
- AC-6: Inverse fields bypass least privilege enforcement
- AC-3: Access enforcement circumvented by inverse fields

## Test Plan
- [ ] check_policy detects NotAction, NotResource, NotPrincipal
- [ ] check_cjis_policy detects NotAction, NotPrincipal on CJI resources
- [ ] Existing tests still pass

Closes #37