### PR TITLE
fix: flag Principal "*" as public access on CJI resources

### DIFF
--- a/policy_checker.py
+++ b/policy_checker.py
@@ -31,6 +31,7 @@ CONTROL_MAP = {
     "not_resource":     {"framework": "NIST 800-53", "control_id": "AC-3"},
     "not_principal":    {"framework": "NIST 800-53", "control_id": "AC-6"},
     "cji_missing_mfa":  {"framework": "CJIS v6.0", "control_id": "IA-2"},
+    "cji_public_access": {"framework": "CJIS v6.0", "control_id": "AC-3"},
     "cji_cross_account": {"framework": "CJIS v6.0", "control_id": "AC-2"},
 }
 
@@ -241,7 +242,15 @@ def check_cjis_policy(policy):
         # The code below normalizes all three forms into a flat list so we
         # can check each principal consistently.
         principal = statement.get("Principal")
-        if principal and principal != "*":
+        if principal == "*":
+            findings.append({
+                "severity": "FAIL",
+                "sid": sid,
+                "message": "CJI resource allows public (anonymous) access"
+                          " via Principal \"*\"",
+                "type": "cji_public_access"
+            })
+        elif principal:
             principals = [principal] if isinstance(principal, str) else []
             if isinstance(principal, dict):
                 principals = principal.get("AWS", [])

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -310,6 +310,24 @@ def test_cjis_with_mfa_null_condition():
     assert len(findings) == 0
 
 
+def test_cjis_public_access_flagged():
+    """Principal "*" on a CJI resource — should be FAIL."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "CJIPublicAccess",
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::cji-data-bucket/*",
+                "Principal": "*"
+            }
+        ]
+    }
+    findings = check_cjis_policy(policy)
+    assert any(f["type"] == "cji_public_access" for f in findings)
+    assert any(f["severity"] == "FAIL" for f in findings if f["type"] == "cji_public_access")
+
+
 def test_cjis_cross_account_no_org_restriction():
     """Cross-account access to CJI resource without org restriction — should be WARN."""
     policy = {


### PR DESCRIPTION
## Summary
- Flag Principal wildcard on CJI resource statements as FAIL-severity (cji_public_access)
- Previously silently skipped by the cross-account check guard
- Add cji_public_access finding type to CONTROL_MAP mapped to CJIS v6.0 AC-3

## Controls Addressed
- AC-3: CJI public access enforcement

## Test Plan
- [ ] Principal wildcard on CJI resource produces FAIL
- [ ] Cross-account check still works (no regression)
- [ ] All 24 tests pass

Closes #38