### PR TITLE
feat: make Effect field comparison case-insensitive

### DIFF
--- a/policy_checker.py
+++ b/policy_checker.py
@@ -56,15 +56,18 @@ def check_policy(policy):
 
         # Skip "Deny" statements - they restrict access rather than grant it,
         # so wildcards in Deny statements are not a security concern.
+        # Case-insensitive comparison handles hand-authored policies with
+        # non-standard casing (e.g., "deny", "DENY").
         effect = statement.get("Effect")
-        if effect == "Deny":
+        if isinstance(effect, str) and effect.lower() == "deny":
             continue
 
         sid = statement.get("Sid")
 
-        # Validate Effect is exactly "Allow". If it's missing, misspelled,
-        # or any other value, the statement is malformed — flag it and skip.
-        if effect != "Allow":
+        # Validate Effect is "Allow" (case-insensitive). If it's missing,
+        # misspelled, or any other value, the statement is malformed — flag
+        # it and skip.
+        if not isinstance(effect, str) or effect.lower() != "allow":
             findings.append({
                 "severity": "WARN",
                 "sid": sid,
@@ -180,13 +183,14 @@ def check_cjis_policy(policy):
 
     for statement in policy.get("Statement", []):
         effect = statement.get("Effect")
-        if effect == "Deny":
+        if isinstance(effect, str) and effect.lower() == "deny":
             continue
 
         sid = statement.get("Sid")
 
-        # Validate Effect is exactly "Allow" before running CJIS checks.
-        if effect != "Allow":
+        # Validate Effect is "Allow" (case-insensitive) before running
+        # CJIS checks.
+        if not isinstance(effect, str) or effect.lower() != "allow":
             findings.append({
                 "severity": "WARN",
                 "sid": sid,

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -520,7 +520,7 @@ def test_cjis_invalid_effect_skips_cjis_checks():
         "Statement": [
             {
                 "Sid": "CJIBadEffect",
-                "Effect": "ALLOW",
+                "Effect": "Allw",
                 "Action": "s3:GetObject",
                 "Resource": "arn:aws:s3:::cji-data-bucket/*",
                 "Principal": "*"
@@ -531,3 +531,91 @@ def test_cjis_invalid_effect_skips_cjis_checks():
     # Only invalid_effect — no cji_missing_mfa or cji_public_access.
     assert len(findings) == 1
     assert findings[0]["type"] == "invalid_effect"
+
+
+# --- Case-insensitive Effect tests ---
+
+def test_deny_case_insensitive_lowercase():
+    """Lowercase "deny" should be skipped like "Deny"."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "LowerDeny",
+                "Effect": "deny",
+                "Action": "*",
+                "Resource": "*"
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert len(findings) == 0
+
+
+def test_deny_case_insensitive_uppercase():
+    """Uppercase "DENY" should be skipped like "Deny"."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "UpperDeny",
+                "Effect": "DENY",
+                "Action": "*",
+                "Resource": "*"
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    assert len(findings) == 0
+
+
+def test_allow_case_insensitive():
+    """Lowercase "allow" should be treated as valid Allow."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "LowerAllow",
+                "Effect": "allow",
+                "Action": "*",
+                "Resource": "*"
+            }
+        ]
+    }
+    findings = check_policy(policy)
+    # Should produce action_wildcard and resource_wildcard, NOT invalid_effect
+    types = [f["type"] for f in findings]
+    assert "invalid_effect" not in types
+    assert "action_wildcard" in types
+
+
+def test_cjis_deny_case_insensitive():
+    """Lowercase "deny" should be skipped by CJIS checks."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "CJILowerDeny",
+                "Effect": "deny",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::cji-data-bucket/*"
+            }
+        ]
+    }
+    findings = check_cjis_policy(policy)
+    assert len(findings) == 0
+
+
+def test_cjis_allow_case_insensitive():
+    """Uppercase "ALLOW" on CJI resource should trigger CJIS checks."""
+    policy = {
+        "Statement": [
+            {
+                "Sid": "CJIUpperAllow",
+                "Effect": "ALLOW",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::cji-data-bucket/*"
+            }
+        ]
+    }
+    findings = check_cjis_policy(policy)
+    # Should trigger cji_missing_mfa, NOT invalid_effect
+    types = [f["type"] for f in findings]
+    assert "invalid_effect" not in types
+    assert "cji_missing_mfa" in types


### PR DESCRIPTION
## Summary
- Use case-insensitive comparison for Effect field in both check_policy() and check_cjis_policy()
- Prevent non-standard casing from causing misclassification
- Add 5 new tests covering lowercase/uppercase Deny and Allow variants

## Test Plan
- [ ] Lowercase deny correctly skipped (not treated as Allow)
- [ ] Uppercase ALLOW correctly treated as valid Allow
- [ ] All 35 tests pass in CI

Closes #43