### PR TITLE
fix: validate types in CJI patterns and Principal handling (#58, #60)

### DIFF
--- a/policy_checker.py
+++ b/policy_checker.py
@@ -308,6 +308,8 @@ def check_cjis_policy(policy, cji_patterns=None):
                 if isinstance(principals, str):
                     principals = [principals]
             for p in principals:
+                if not isinstance(p, str):
+                    continue
                 if ":root" in p and "arn:aws:iam::" in p:
                     account_condition = condition.get("StringEquals", {}).get("aws:PrincipalOrgID")
                     if not account_condition:
@@ -393,6 +395,11 @@ if __name__ == "__main__":
                 print("CJI patterns file must contain a JSON array.",
                       file=sys.stderr)
                 sys.exit(2)
+            for i, p in enumerate(cji_patterns):
+                if not isinstance(p, str):
+                    print(f"CJI pattern at index {i} must be a string (got {type(p).__name__}).",
+                          file=sys.stderr)
+                    sys.exit(2)
         except FileNotFoundError:
             print(f"{args.cji_patterns} doesn't exist.", file=sys.stderr)
             sys.exit(2)


### PR DESCRIPTION
## Summary

Fix two type-validation bugs that crash the checker on malformed input:

### #58 — Non-string elements in `--cji-patterns` (P2)

`isinstance(cji_patterns, list)` only validates the outer container. A JSON file like `[123, null, ["nested"]]` passes validation and crashes inside `re.compile` with an opaque `TypeError`.

**Fix:** After the outer-list check, validate each element is a string. Non-string elements now produce a clear error message with the index and exit code 2.

### #60 — Non-string Principal items in cross-account check (P3)

`":root" in p` at line 311 is called without confirming `p` is a string. A policy with `"Principal": {"AWS": [123, null]}` raises `TypeError: argument of type 'int' is not iterable`, crashing the entire function and losing all findings collected so far.

**Fix:** Add `isinstance(p, str)` guard before the `in` check; skip non-string items with `continue`.

## Testing

- All 41 existing tests pass
- Verified fix #60: policy with `{"AWS": [123, None, "arn:..."]}` no longer crashes, correctly reports findings for the valid string principal
- Verified fix #58: `--cji-patterns` file with `[123]` now exits with code 2 and message `CJI pattern at index 0 must be a string (got int).`

## Issues

- Fixes #58
- Fixes #60