### PR TITLE
docs: upgrade README badges to portfolio house style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# Policy Checker
-
+![License](https://img.shields.io/badge/License-MIT-green?style=flat)
+![Python](https://img.shields.io/badge/Python-3.11%2B-3776ab?style=flat)
+![AWS](https://img.shields.io/badge/AWS-IAM%20Policy-FF9900?style=flat&logo=amazonwebservices)
+![NIST 800-53](https://img.shields.io/badge/NIST-800--53%20Rev%205-004990?style=flat)
+![FedRAMP](https://img.shields.io/badge/FedRAMP-High%20Baseline-0071bc?style=flat)
+![CJIS](https://img.shields.io/badge/CJIS-Security%20Policy%20v6.0-cc0000?style=flat)
 [![Policy Check](https://github.com/0xBahalaNa/policy_checker/actions/workflows/policy-check.yml/badge.svg)](https://github.com/0xBahalaNa/policy_checker/actions/workflows/policy-check.yml)
+
+# Policy Checker
 
 This script loads an AWS IAM policy file and checks if it is overly permissive.
 


### PR DESCRIPTION
## Summary
- Upgrades the README badge block to the portfolio house style — adds License, Python 3.11+, AWS IAM Policy, NIST 800-53 Rev 5, FedRAMP High Baseline, and CJIS Security Policy v6.0
- Existing CI workflow badge preserved as the last badge in the block (badge URL kept intact — fix tracked separately)
- Badges now sit above the H1, matching `aws-compliance-as-code`, `aws-config-compliance-monitor`, `aws-grc-terraform-modules`, and the other portfolio repos
- No body content changed below the badge block

## Test Plan
- [ ] Open the README on GitHub after merge and confirm all seven badges render in order
- [ ] Confirm the H1 and Usage / Examples / What It Does sections still appear unchanged below the badges
- [ ] Verify the CI status badge still resolves (or note that it 404s — separate follow-up tracks the `policy_checker` → `policy-checker` rename URL fix)

Closes #70