### PR TITLE
docs: add Architecture Overview Mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,26 @@
 
 This script loads an AWS IAM policy file and checks if it is overly permissive.
 
+## Architecture Overview
+
+```mermaid
+flowchart TD
+    CLI["policy_checker.py<br/>policy.json CLI"] --> PARSE["Parse Statement entries"]
+    PARSE --> WILD["Permissive checks<br/>Action/Resource * · service:*"]
+    PARSE --> CJI["CJI-tagged checks<br/>MFA · cross-account"]
+    WILD --> FIND["Findings"]
+    CJI --> FIND
+    FIND --> TXT["Text summary<br/>default output"]
+    FIND --> MAP["Map to NIST 800-53 / CJIS IDs"]
+    MAP --> JSON["JSON evidence<br/>--output json"]
+    TXT --> HUM["Auditors / CLI review"]
+    JSON --> PIPE["OSCAL · CI workflow<br/>control ID + UTC timestamp"]
+```
+
+Editable Mermaid source (kept in sync with the fence above): [`docs/architecture.mmd`](docs/architecture.mmd).
+
+`policy_checker.py` parses each IAM `Statement` and flags overly permissive wildcards and CJI-tagged MFA / cross-account gaps. Default output is a text summary (severity, statement ID, message — no control IDs). With `--output json`, findings are enriched with NIST 800-53 / CJIS control IDs and UTC timestamps for CI and OSCAL consumers.
+
 ## Usage
 ```
 python policy_checker.py <filename> [--output text|json]

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -1,0 +1,14 @@
+%% Editable Mermaid source for the README "Architecture Overview" section.
+%% Keep this file in sync with the inline ```mermaid fence in README.md.
+%% Diff-able source of truth for the architecture graph (no separate PNG export).
+flowchart TD
+    CLI["policy_checker.py<br/>policy.json CLI"] --> PARSE["Parse Statement entries"]
+    PARSE --> WILD["Permissive checks<br/>Action/Resource * · service:*"]
+    PARSE --> CJI["CJI-tagged checks<br/>MFA · cross-account"]
+    WILD --> FIND["Findings"]
+    CJI --> FIND
+    FIND --> TXT["Text summary<br/>default output"]
+    FIND --> MAP["Map to NIST 800-53 / CJIS IDs"]
+    MAP --> JSON["JSON evidence<br/>--output json"]
+    TXT --> HUM["Auditors / CLI review"]
+    JSON --> PIPE["OSCAL · CI workflow<br/>control ID + UTC timestamp"]


### PR DESCRIPTION
## Summary
- Add an **Architecture Overview** section to the README: a Mermaid flowchart of the check flow — `policy_checker.py` → parse IAM `Statement` entries → permissive wildcard checks + CJI-tagged MFA / cross-account checks → findings → default text summary (severity / statement ID / message) or `--output json` path through NIST 800-53 / CJIS control-ID enrichment (`enrich_findings`) with UTC timestamps for CI / OSCAL consumers
- Add `docs/architecture.mmd` — diff-able, editable Mermaid source kept byte-identical with the README fence (diagram-as-code; no PNG export to go stale)
- Diagram routes text output around the MAP node (JSON-only enrichment), matching `policy_checker.py`

Documentation-only: no checker or control logic changed.

## Test Plan
- [x] README fence and `docs/architecture.mmd` graph bodies verified byte-identical
- [x] Routing verified against source: text path skips `enrich_findings`; JSON path maps to NIST 800-53 / CJIS only
- [ ] Mermaid fence renders correctly on GitHub