### PR TITLE
fix: update CJIS framework strings to Security Policy v6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![AWS](https://img.shields.io/badge/AWS-IAM%20Policy-FF9900?style=flat&logo=amazonwebservices)
 ![NIST 800-53](https://img.shields.io/badge/NIST-800--53%20Rev%205-004990?style=flat)
 ![FedRAMP](https://img.shields.io/badge/FedRAMP-High%20Baseline-0071bc?style=flat)
-![CJIS](https://img.shields.io/badge/CJIS-Security%20Policy%20v6.0-cc0000?style=flat)
+![CJIS](https://img.shields.io/badge/CJIS-Security%20Policy%20v6.1-cc0000?style=flat)
 [![Policy Check](https://github.com/0xBahalaNa/policy_checker/actions/workflows/policy-check.yml/badge.svg)](https://github.com/0xBahalaNa/policy_checker/actions/workflows/policy-check.yml)
 
 # Policy Checker
@@ -49,17 +49,17 @@ python policy_checker.py policy.json --output json > results.json
     - `Action` is `*`
     - `Resource` is `*`
     - Service-level wildcards (e.g., `s3:*`, `iam:*`)
-- Performs CJIS v6.0 checks on CJI-tagged resources:
+- Performs CJIS v6.1 checks on CJI-tagged resources:
     - Missing MFA condition (`aws:MultiFactorAuthPresent`)
     - Cross-account access without org restriction
-- Maps findings to NIST 800-53 and CJIS v6.0 compliance controls.
+- Maps findings to NIST 800-53 and CJIS v6.1 compliance controls.
 - Prints a summary of the results.
 
 ## Compliance Mapping
 
-Each check maps to controls across NIST 800-53 Rev 5, FedRAMP, and CJIS v6.0:
+Each check maps to controls across NIST 800-53 Rev 5, FedRAMP, and CJIS v6.1:
 
-| Check | NIST 800-53 | FedRAMP | CJIS v6.0 |
+| Check | NIST 800-53 | FedRAMP | CJIS v6.1 |
 |-------|-------------|---------|-----------|
 | Action is `*` | AC-6 (Least Privilege) | AC-6 | AC-6 |
 | Resource is `*` | AC-3 (Access Enforcement) | AC-3 | AC-3 |
@@ -76,9 +76,9 @@ The JSON output (`--output json`) provides machine-readable evidence for complia
 
 FedRAMP 20x requires compliance controls to be validated through automated, machine-readable evidence rather than manual documentation. The `--output json` format produces structured findings that can feed directly into OSCAL-based evidence pipelines. Each finding includes the framework, control ID, severity, resource, and UTC timestamp required for continuous monitoring and authorization packages.
 
-## CJIS v6.0 Relevance
+## CJIS v6.1 Relevance
 
-CJIS v6.0 (published Dec 27, 2024; default audit baseline from April 1, 2026; Priority 2-4 fully enforceable Oct 1, 2027) aligns with NIST 800-53 Rev 5 but adds requirements specific to systems handling Criminal Justice Information (CJI). This tool validates that IAM policies enforce least privilege (AC-6), access control enforcement (AC-3), and MFA requirements (IA-2) for CJI resources, helping agencies demonstrate that AWS permissions governing CJI data stores are scoped appropriately.
+CJIS Security Policy v6.1 (released June 25, 2026) is the current policy, aligned with NIST 800-53 Rev 5. v6.x has been the default audit baseline since April 1, 2026 (v5.9.5 sunset March 31, 2026); modernized Priority 2-4 controls are fully enforceable Oct 1, 2027 (timing varies by state CSA). It adds requirements specific to systems handling Criminal Justice Information (CJI). This tool validates that IAM policies enforce least privilege (AC-6), access control enforcement (AC-3), and MFA requirements (IA-2) for CJI resources, helping agencies demonstrate that AWS permissions governing CJI data stores are scoped appropriately.
 
 ## Output Formats
 

--- a/examples/sample-output.json
+++ b/examples/sample-output.json
@@ -5,7 +5,7 @@
     "finding": "Action is \"*\"",
     "severity": "FAIL",
     "resource": "test-policy.json",
-    "timestamp": "2026-02-15T23:06:25.217302+00:00"
+    "timestamp": "2026-08-14T22:31:58.146293+00:00"
   },
   {
     "framework": "NIST 800-53",
@@ -13,7 +13,7 @@
     "finding": "Resource is \"*\"",
     "severity": "FAIL",
     "resource": "test-policy.json",
-    "timestamp": "2026-02-15T23:06:25.217302+00:00"
+    "timestamp": "2026-08-14T22:31:58.146293+00:00"
   },
   {
     "framework": "NIST 800-53",
@@ -21,7 +21,7 @@
     "finding": "Action is \"*\"",
     "severity": "FAIL",
     "resource": "test-policy.json",
-    "timestamp": "2026-02-15T23:06:25.217302+00:00"
+    "timestamp": "2026-08-14T22:31:58.146293+00:00"
   },
   {
     "framework": "NIST 800-53",
@@ -29,7 +29,7 @@
     "finding": "Resource is \"*\"",
     "severity": "FAIL",
     "resource": "test-policy.json",
-    "timestamp": "2026-02-15T23:06:25.217302+00:00"
+    "timestamp": "2026-08-14T22:31:58.146293+00:00"
   },
   {
     "framework": "NIST 800-53",
@@ -37,7 +37,7 @@
     "finding": "Action \"iam:*\" grants full access to a service",
     "severity": "WARN",
     "resource": "test-policy.json",
-    "timestamp": "2026-02-15T23:06:25.217302+00:00"
+    "timestamp": "2026-08-14T22:31:58.146293+00:00"
   },
   {
     "framework": "NIST 800-53",
@@ -45,7 +45,7 @@
     "finding": "Resource is \"*\"",
     "severity": "FAIL",
     "resource": "test-policy.json",
-    "timestamp": "2026-02-15T23:06:25.217302+00:00"
+    "timestamp": "2026-08-14T22:31:58.146293+00:00"
   },
   {
     "framework": "NIST 800-53",
@@ -53,7 +53,7 @@
     "finding": "Action \"s3:*\" grants full access to a service",
     "severity": "WARN",
     "resource": "test-policy.json",
-    "timestamp": "2026-02-15T23:06:25.217302+00:00"
+    "timestamp": "2026-08-14T22:31:58.146293+00:00"
   },
   {
     "framework": "NIST 800-53",
@@ -61,30 +61,30 @@
     "finding": "Resource is \"*\"",
     "severity": "FAIL",
     "resource": "test-policy.json",
-    "timestamp": "2026-02-15T23:06:25.217302+00:00"
+    "timestamp": "2026-08-14T22:31:58.146293+00:00"
   },
   {
-    "framework": "CJIS v6.0",
+    "framework": "CJIS v6.1",
     "control_id": "IA-2",
     "finding": "CJI resource access without MFA condition (aws:MultiFactorAuthPresent)",
     "severity": "FAIL",
     "resource": "test-policy.json",
-    "timestamp": "2026-02-15T23:06:25.217302+00:00"
+    "timestamp": "2026-08-14T22:31:58.146293+00:00"
   },
   {
-    "framework": "CJIS v6.0",
+    "framework": "CJIS v6.1",
     "control_id": "IA-2",
     "finding": "CJI resource access without MFA condition (aws:MultiFactorAuthPresent)",
     "severity": "FAIL",
     "resource": "test-policy.json",
-    "timestamp": "2026-02-15T23:06:25.217302+00:00"
+    "timestamp": "2026-08-14T22:31:58.146293+00:00"
   },
   {
-    "framework": "CJIS v6.0",
+    "framework": "CJIS v6.1",
     "control_id": "AC-2",
     "finding": "Cross-account access to CJI resource without org restriction",
     "severity": "WARN",
     "resource": "test-policy.json",
-    "timestamp": "2026-02-15T23:06:25.217302+00:00"
+    "timestamp": "2026-08-14T22:31:58.146293+00:00"
   }
 ]

--- a/policy_checker.py
+++ b/policy_checker.py
@@ -2,7 +2,7 @@
 policy_checker.py
 
 This script loads an AWS IAM policy JSON file and checks for overly permissive statements,
-such as wildcard ("*") Actions or Resources. It also performs CJIS v6.0 specific checks
+such as wildcard ("*") Actions or Resources. It also performs CJIS v6.1 specific checks
 for policies accessing Criminal Justice Information (CJI) resources.
 
 Exit codes:
@@ -31,9 +31,9 @@ CONTROL_MAP = {
     "not_action":       {"framework": "NIST 800-53", "control_id": "AC-6"},
     "not_resource":     {"framework": "NIST 800-53", "control_id": "AC-3"},
     "not_principal":    {"framework": "NIST 800-53", "control_id": "AC-6"},
-    "cji_missing_mfa":  {"framework": "CJIS v6.0", "control_id": "IA-2"},
-    "cji_public_access": {"framework": "CJIS v6.0", "control_id": "AC-3"},
-    "cji_cross_account": {"framework": "CJIS v6.0", "control_id": "AC-2"},
+    "cji_missing_mfa":  {"framework": "CJIS v6.1", "control_id": "IA-2"},
+    "cji_public_access": {"framework": "CJIS v6.1", "control_id": "AC-3"},
+    "cji_cross_account": {"framework": "CJIS v6.1", "control_id": "AC-2"},
     "invalid_effect":   {"framework": "NIST 800-53", "control_id": "CM-6"},
 }
 
@@ -180,7 +180,7 @@ def check_policy(policy):
 
 def check_cjis_policy(policy, cji_patterns=None):
     """
-    Check a parsed IAM policy for CJIS v6.0 specific requirements.
+    Check a parsed IAM policy for CJIS v6.1 specific requirements.
 
     Checks for:
         - Policies accessing CJI resources without MFA conditions (IA-2)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -4,7 +4,7 @@ Unit tests for policy_checker.py.
 Covers four areas:
     1. Basic wildcard detection   — Action "*", Resource "*", service-level wildcards (e.g., "s3:*")
     2. Effect field validation    — missing, misspelled, or invalid Effect values (CM-6)
-    3. CJIS v6.0 compliance       — MFA requirement (IA-2), cross-account access (AC-2)
+    3. CJIS v6.1 compliance       — MFA requirement (IA-2), cross-account access (AC-2)
     4. Finding enrichment         — timestamp format, framework/control_id metadata
 
 Run the full suite with:


### PR DESCRIPTION
## Summary
- Updated all CJIS references from Security Policy v6.0 to v6.1 (released 06/25/2026, CY2025 APB corrections release)
- Applied the canonical rollout wording: v6.x default audit baseline since April 1, 2026 (v5.9.5 sunset March 31, 2026); Priority 2-4 fully enforceable Oct 1, 2027
- Replaced remaining legacy v5.9-style section citations with 800-53 control-ID citations where present

## Test Plan
- [x] grep sweep: no remaining v6.0 version strings or legacy 5.x citations in living files
- [x] pytest: 41 passed
- [x] examples/sample-output.json regenerated from test-policy.json